### PR TITLE
Pr 1

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -13,8 +13,8 @@ if [[ "$(uname -s)" == 'Darwin' ]]; then
         eval "$(pyenv init -)"
     fi
 
-    pyenv install 3.7.0
-    pyenv virtualenv 3.7.0 conan
+    pyenv install 3.7.1
+    pyenv virtualenv 3.7.1 conan
     pyenv rehash
     pyenv activate conan
 fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ environment:
           CONAN_BUILD_TYPES: Debug
 
 install:
-  - set PATH=%PATH%;%PYTHON%/Scripts/
+  - set PATH=%PYTHON%;%PYTHON%/Scripts/;%PATH%
   - pip.exe install conan --upgrade
   - pip.exe install conan_package_tools bincrafters_package_tools
   - conan user # It creates the conan data directory

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,8 @@
-from conans import ConanFile, tools, MSBuild, AutoToolsBuildEnvironment
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import os
-import os.path
+from conans import ConanFile, tools, MSBuild, AutoToolsBuildEnvironment
+
 
 class SDL2TtfConan(ConanFile):
     name = "sdl2_ttf"
@@ -8,7 +10,7 @@ class SDL2TtfConan(ConanFile):
     description = "A TrueType font library for SDL2"
     topics = ("conan", "sdl2", "sdl2_ttf", "sdl", "sdl_ttf", "ttf", "font")
     url = "https://github.com/bincrafters/conan-sdl2_ttf"
-    homepage = "https://www.libsdl.org/projects/SDL_ttf/"
+    homepage = "https://www.libsdl.org/projects/SDL_ttf"
     author = "Bincrafters <bincrafters@gmail.com>"
     license = "ZLIB"
     exports = "LICENSE.md"
@@ -19,15 +21,14 @@ class SDL2TtfConan(ConanFile):
     }
     default_options = {
         "shared": False,
-        "fPIC": False,
+        "fPIC": True,
     }
-
-    _source_subfolder = "SDL2_ttf-{}".format(version)
-
     requires = (
         "freetype/2.9.0@bincrafters/stable",
         "sdl2/2.0.8@bincrafters/stable",
     )
+    _source_subfolder = "source_subfolder"
+    _autotools = None
 
     def config_options(self):
         del self.settings.compiler.libcxx
@@ -37,82 +38,88 @@ class SDL2TtfConan(ConanFile):
             del self.options.fPIC
 
     def source(self):
-        tools.get("https://www.libsdl.org/projects/SDL_ttf/release/{}.tar.gz".format(
-            self._source_subfolder))
-        if self.settings.compiler == "Visual Studio":
-            visualc = os.path.join(self._source_subfolder, "VisualC")
-
-            projects = (
-                os.path.join(visualc, "SDL_ttf.vcxproj"),
-                os.path.join(visualc, "glfont", "glfont.vcxproj"),
-                os.path.join(visualc, "showfont", "showfont.vcxproj"),
-            )
-
-            # Patch out dependency on packaged freetype
-            tools.replace_in_file(projects[0], "external\\include;", "")
-            tools.replace_in_file(projects[0], "external\\lib\\x86;", "")
-            tools.replace_in_file(projects[0], "external\\lib\\x64;", "")
-            tools.replace_in_file(projects[0], "libfreetype-6.lib;", "")
-
-            # Patch in some missing libraries
-            for project in projects:
-                tools.replace_in_file(project,
-                                      "<AdditionalDependencies>",
-                                      "<AdditionalDependencies>WinMM.lib;version.lib;Imm32.lib;")
+        extracted_folder = "SDL2_ttf-{}".format(self.version)
+        sha256 = "34db5e20bcf64e7071fe9ae25acaa7d72bdc4f11ab3ce59acc768ab62fe39276"
+        tools.get("{}/release/{}.tar.gz".format(self.homepage, extracted_folder), sha256=sha256)
+        os.rename(extracted_folder, self._source_subfolder)
 
     def build(self):
         if self.settings.compiler == "Visual Studio":
-            self.build_with_vs()
+            self._build_with_vs()
         else:
             if self.settings.os == "Macos":
                 with tools.environment_append({"DYLD_LIBRARY_PATH": self.deps_cpp_info["sdl2"].libdirs}):
-                    self.build_with_make()
+                    self._build_with_make()
             else:
-                self.build_with_make()
+                self._build_with_make()
 
-    def build_with_vs(self):
+    def _build_with_vs(self):
+        visualc = os.path.join(self._source_subfolder, "VisualC")
+        projects = (
+            os.path.join(visualc, "SDL_ttf.vcxproj"),
+            os.path.join(visualc, "glfont", "glfont.vcxproj"),
+            os.path.join(visualc, "showfont", "showfont.vcxproj"),
+        )
+
+        # Patch out dependency on packaged freetype
+        tools.replace_in_file(projects[0], "external\\include;", "")
+        tools.replace_in_file(projects[0], "external\\lib\\x86;", "")
+        tools.replace_in_file(projects[0], "external\\lib\\x64;", "")
+        tools.replace_in_file(projects[0], "libfreetype-6.lib;", "")
+
+        # Patch in some missing libraries
+        for project in projects:
+            tools.replace_in_file(project,
+                                    "<AdditionalDependencies>",
+                                    "<AdditionalDependencies>WinMM.lib;version.lib;Imm32.lib;")
         msbuild = MSBuild(self)
         msbuild.build(os.path.join(self._source_subfolder, "VisualC", "SDL_ttf.sln"),
                       platforms={"x86": "Win32",
                                  "x86_64": "x64"},
                       toolset=self.settings.compiler.toolset)
 
-    def build_with_make(self):
-        autotools = AutoToolsBuildEnvironment(self)
-        args = [
-            "--with-freetype-prefix=" + self.deps_cpp_info["freetype"].rootpath,
-            "--with-sdl-prefix=" + self.deps_cpp_info["sdl2"].rootpath,
-        ]
-        if self.options.shared:
-            args.extend(['--enable-shared', '--disable-static'])
-        else:
-            args.extend(['--enable-static', '--disable-shared'])
-        autotools.configure(configure_dir=self._source_subfolder, args=args)
+    def _configure_autotools(self):
+        if not self._autotools:
+            self._autotools = AutoToolsBuildEnvironment(self)
+            args = [
+                "--with-freetype-prefix=" + self.deps_cpp_info["freetype"].rootpath,
+                "--with-sdl-prefix=" + self.deps_cpp_info["sdl2"].rootpath,
+            ]
+            if self.options.shared:
+                args.extend(['--enable-shared', '--disable-static'])
+            else:
+                args.extend(['--enable-static', '--disable-shared'])
+            self._autotools.configure(configure_dir=self._source_subfolder, args=args)
 
-        patches = (
-            ('\nnoinst_PROGRAMS = ', '\n# Removed by conan: noinst_PROGRAMS = '),
-            ('\nLIBS = ', '\n# Removed by conan: LIBS = '),
-            ('\nLIBTOOL = ', '\nLIBS = {}\nLIBTOOL = '.format(" ".join(["-l%s" % lib for lib in self.deps_cpp_info.libs]))),
-            ('\nSDL_CFLAGS =', '\n# Removed by conan: SDL_CFLAGS ='),
-            ('\nSDL_LIBS =' , '\n# Removed by conan: SDL_LIBS ='),
-        )
+            patches = (
+                ('\nnoinst_PROGRAMS = ', '\n# Removed by conan: noinst_PROGRAMS = '),
+                ('\nLIBS = ', '\n# Removed by conan: LIBS = '),
+                ('\nLIBTOOL = ', '\nLIBS = {}\nLIBTOOL = '.format(" ".join(["-l%s" % lib for lib in self.deps_cpp_info.libs]))),
+                ('\nSDL_CFLAGS =', '\n# Removed by conan: SDL_CFLAGS ='),
+                ('\nSDL_LIBS =' , '\n# Removed by conan: SDL_LIBS ='),
+            )
 
-        for old_str, new_str in patches:
-            tools.replace_in_file("Makefile", old_str, new_str)
+            for old_str, new_str in patches:
+                tools.replace_in_file("Makefile", old_str, new_str)
+        return self._autotools
 
+    def _build_with_make(self):
+        autotools = self._configure_autotools()
         autotools.make()
-        autotools.install()
 
     def package(self):
+        self.copy(pattern="COPYING.txt", dst="licenses", src=self._source_subfolder)
         if self.settings.compiler == "Visual Studio":
             self.copy(pattern="SDL_ttf.h",
                       dst=os.path.join("include", "SDL2"),
                       src=self._source_subfolder,
                       keep_path=False)
-            self.copy(pattern="*{}SDL2_ttf.lib".format(os.sep), dst="lib", keep_path=False)
-            self.copy(pattern="*{}SDL2_ttf.pdb".format(os.sep), dst="lib", keep_path=False)
-            self.copy(pattern="*{}SDL2_ttf.dll".format(os.sep), dst="bin", keep_path=False)
-            self.copy(pattern="*{}COPYING.txt".format(os.sep), dst="licenses", keep_path=False)
+            self.copy(pattern="*.lib", dst="lib", src=self._source_subfolder, keep_path=False)
+            self.copy(pattern="*.pdb", dst="lib", src=self._source_subfolder, keep_path=False)
+            self.copy(pattern="*.dll", dst="bin", src=self._source_subfolder, keep_path=False)
+        else:
+            autotools = self._configure_autotools()
+            autotools.install()
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)


### PR DESCRIPTION
This error occurs during build:
```
C:\Users\maarten\Documents\Visual Studio 2017\Projects\conan-sdl2_ttf\tmp>conan
build .. -if bin -bf bin -sf src -pf pkg
Project: Running build()
C:\Users\maarten\AppData\Roaming\Python\Python37\site-packages\conans\util\fallbacks.py:9: UserWarning: Provide the output argument explicitly to function 'conans.client.tools.win.vcvars_command'
  warnings.warn("Provide the output argument explicitly{}".format(fn_str))

----Running------
> set "VSCMD_START_DIR=%CD%" && call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC/Auxiliary/Build/vcvarsall.bat" amd64 && devenv "C:\Users\maarten\Documents\Visual Studio 2017\Projects\conan-sdl2_ttf\tmp\src\source_subfolder\VisualC\SDL_ttf.sln" /upgrade && msbuild "C:\Users\maarten\Documents\Visual Studio 2017\Projects\conan-sdl2_ttf\tmp\src\source_subfolder\VisualC\SDL_ttf.sln" /p:Configuration="Release" /p:UseEnv=true /p:Platform="x64" /m:8 /p:ForceImportBeforeCppTargets="conan_build.props"
-----------------
**********************************************************************
** Visual Studio 2017 Developer Command Prompt v15.9.5
** Copyright (c) 2017 Microsoft Corporation
**********************************************************************
[vcvarsall.bat] Environment initialized for: 'x64'

Microsoft Visual Studio 2017 Version 15.0.28307.280.
Copyright (C) Microsoft Corp. All rights reserved.
Upgrading project 'SDL2_ttf'...
        Configuration 'Debug|Win32': no platform toolset upgrade required. Platform Toolset is 'v141'.
        Configuration 'Debug|x64': no platform toolset upgrade required. Platform Toolset is 'v141'.
        Configuration 'Release|Win32': no platform toolset upgrade required. Platform Toolset is 'v141'.
        Configuration 'Release|x64': no platform toolset upgrade required. Platform Toolset is 'v141'.
Upgrading project 'showfont'...
        Configuration 'Debug|Win32': no platform toolset upgrade required. Platform Toolset is 'v141'.
        Configuration 'Debug|x64': no platform toolset upgrade required. Platform Toolset is 'v141'.
        Configuration 'Release|Win32': no platform toolset upgrade required. Platform Toolset is 'v141'.
        Configuration 'Release|x64': no platform toolset upgrade required. Platform Toolset is 'v141'.
Upgrading project 'glfont'...
        Configuration 'Debug|Win32': no platform toolset upgrade required. Platform Toolset is 'v141'.
        Configuration 'Debug|x64': no platform toolset upgrade required. Platform Toolset is 'v141'.
        Configuration 'Release|Win32': no platform toolset upgrade required. Platform Toolset is 'v141'.
        Configuration 'Release|x64': no platform toolset upgrade required. Platform Toolset is 'v141'.

Migration completed successfully, but some warnings were detected during migration.
For more information, see the migration report:
C:\Users\maarten\Documents\Visual Studio 2017\Projects\conan-sdl2_ttf\tmp\src\source_subfolder\VisualC\UpgradeLog4.htm
Microsoft (R) Build Engine version 15.9.21+g9802d43bc3 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

Build started 26-1-2019 03:35:51.
     1>Project "C:\Users\maarten\Documents\Visual Studio 2017\Projects\conan-sd
       l2_ttf\tmp\src\source_subfolder\VisualC\SDL_ttf.sln" on node 1 (default
       targets).
     1>ValidateSolutionConfiguration:
         Building solution configuration "Release|x64".
     1>Project "C:\Users\maarten\Documents\Visual Studio 2017\Projects\conan-sd
       l2_ttf\tmp\src\source_subfolder\VisualC\SDL_ttf.sln" (1) is building "C:
       \Users\maarten\Documents\Visual Studio 2017\Projects\conan-sdl2_ttf\tmp\
       src\source_subfolder\VisualC\SDL_ttf.vcxproj" (2) on node 1 (default tar
       gets).
     2>C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\ID
       E\VC\VCTargets\Microsoft.Cpp.WindowsSDK.targets(46,5): error MSB8036: Th
       e Windows SDK version 8.1 was not found. Install the required version of
        Windows SDK or change the SDK version in the project property pages or
       by right-clicking the solution and selecting "Retarget solution". [C:\Us
       ers\maarten\Documents\Visual Studio 2017\Projects\conan-sdl2_ttf\tmp\src
       \source_subfolder\VisualC\SDL_ttf.vcxproj]
     2>Done Building Project "C:\Users\maarten\Documents\Visual Studio 2017\Pro
       jects\conan-sdl2_ttf\tmp\src\source_subfolder\VisualC\SDL_ttf.vcxproj" (
       default targets) -- FAILED.
     1>Done Building Project "C:\Users\maarten\Documents\Visual Studio 2017\Pro
       jects\conan-sdl2_ttf\tmp\src\source_subfolder\VisualC\SDL_ttf.sln" (defa
       ult targets) -- FAILED.

Build FAILED.

       "C:\Users\maarten\Documents\Visual Studio 2017\Projects\conan-sdl2_ttf\t
       mp\src\source_subfolder\VisualC\SDL_ttf.sln" (default target) (1) ->
       "C:\Users\maarten\Documents\Visual Studio 2017\Projects\conan-sdl2_ttf\t
       mp\src\source_subfolder\VisualC\SDL_ttf.vcxproj" (default target) (2) ->
       (_CheckWindowsSDKInstalled target) ->
         C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\
       IDE\VC\VCTargets\Microsoft.Cpp.WindowsSDK.targets(46,5): error MSB8036:
       The Windows SDK version 8.1 was not found. Install the required version
       of Windows SDK or change the SDK version in the project property pages o
       r by right-clicking the solution and selecting "Retarget solution". [C:\
       Users\maarten\Documents\Visual Studio 2017\Projects\conan-sdl2_ttf\tmp\s
       rc\source_subfolder\VisualC\SDL_ttf.vcxproj]

    0 Warning(s)
    1 Error(s)

Time Elapsed 00:00:02.04
ERROR: sdl2_ttf/2.0.14@PROJECT: Error in build() method, line 77
        self._build_with_vs()
while calling '_build_with_vs', line 91
        toolset=self.settings.compiler.toolset)
        ConanException: Error 1 while executing set "VSCMD_START_DIR=%CD%" && call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC/Auxiliary/Build/vcvarsall.bat" amd64 && devenv "C:\Users\maarten\Documents\Visual Studio 2017\Projects\conan-sdl2_ttf\tmp\src\source_subfolder\VisualC\SDL_ttf.sln" /upgrade && msbuild "C:\Users\maarten\Documents\Visual Studio 2017\Projects\conan-sdl2_ttf\tmp\src\source_subfolder\VisualC\SDL_ttf.sln" /p:Configuration="Release" /p:UseEnv=true /p:Platform="x64" /m:8 /p:ForceImportBeforeCppTargets="conan_build.props"
```

This can be fixed by adding
```
VisualStudioVersion = 15.0.28307.271
MinimumVisualStudioVersion = 10.0.40219.1
```

To the top of `SDL_ttf.sln`

(These lines are added when I open SDL_ttf.sln in Visual Studio and set the Windows SDK to 10.0.1773.0